### PR TITLE
비밀의방, 일촌리스트프사이름클릭이동, 버튼들 opacity css

### DIFF
--- a/FeatherWorld/src/main/resources/static/css/board/boardDetail.css
+++ b/FeatherWorld/src/main/resources/static/css/board/boardDetail.css
@@ -110,6 +110,13 @@ body {
   font-size: 0.85rem;
 }
 
+.back-button:hover,
+#updateBtn:hover,
+#deleteBtn:hover {
+  background-color: #9f2120;
+  opacity: 90%;
+}
+
 .container {
   display: flex;
   flex-direction: column;

--- a/FeatherWorld/src/main/resources/static/css/board/boardWrite.css
+++ b/FeatherWorld/src/main/resources/static/css/board/boardWrite.css
@@ -26,7 +26,6 @@
 
 .back-button span:hover {
   background-color: #7d1a19;
-  transform: translateX(-3px);
 }
 
 /* 게시글 작성 폼 */
@@ -125,7 +124,8 @@
   overflow: hidden;
 }
 
-.image-slot:hover, .image-slot.drag-over {
+.image-slot:hover,
+.image-slot.drag-over {
   border-color: #9f2120;
   background-color: #fafafa;
 }
@@ -206,7 +206,6 @@
 
 .btn-confirm:hover {
   background-color: #7d1a19;
-  transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(159, 33, 32, 0.3);
 }
 

--- a/FeatherWorld/src/main/resources/static/css/board/comment.css
+++ b/FeatherWorld/src/main/resources/static/css/board/comment.css
@@ -11,6 +11,12 @@
   color: #8e8e8e;
 }
 
+#commentContent:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
+}
+
 .comment-list {
   width: 100%;
 }
@@ -111,6 +117,12 @@
   transition: background-color 0.2s;
 }
 
+.reply-btn:hover,
+button:hover {
+  background-color: #9f2120;
+  opacity: 90%;
+}
+
 /* 댓글 입력창 */
 .comment-write-area {
   display: flex;
@@ -163,6 +175,12 @@
   padding: 10px;
 }
 
+.commentInsertContent:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
+}
+
 #commentArea {
   clear: both;
   width: 100%;
@@ -192,4 +210,16 @@
 .reply-wrapper {
   width: 100%;
   box-sizing: border-box;
+}
+
+.update-textarea:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
+}
+
+.commentInsertContent:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
 }

--- a/FeatherWorld/src/main/resources/static/css/friendList/sendFriendReq.css
+++ b/FeatherWorld/src/main/resources/static/css/friendList/sendFriendReq.css
@@ -1,0 +1,141 @@
+/* 메인 콘텐츠 스타일 */
+.main-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex-grow: 1;
+  padding: 20px 20px 20px 0; /* 위, 오른쪽, 아래, 왼쪽 */
+  height: 600px;
+}
+
+/* 뒤로가기 버튼 */
+.back-button {
+  margin-left: 20px;
+  border: none;
+}
+
+.back-button span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  background-color: #9f2120;
+  color: white;
+  border-radius: 50%;
+  cursor: pointer;
+  font-size: 18px;
+  transition: all 0.3s ease;
+  border: none; /* <- 이걸 추가해줘야 네모 테두리 제거 */
+  outline: none; /* <- 클릭 시 파란 외곽선 제거용 */
+}
+
+.back-button span:hover {
+  background-color: #7d1a19;
+}
+
+/* 일촌 요청 보내기 타이틀 */
+.reqTitle {
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  margin: 30px 30px 50px 30px;
+}
+.reqTitle-font {
+  font-weight: bold;
+  margin: 10px;
+  font-size: xx-large;
+}
+
+/* 게시글 작성 폼 */
+.board-write {
+  width: 100%;
+}
+
+.board-form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  align-items: center;
+}
+
+/* 입력 그룹 */
+.input-group {
+  width: 100%;
+}
+
+.input-group.mb-4 {
+  margin-bottom: 20px;
+}
+
+/* 새로 정할 일촌명 입력 */
+.form-control {
+  width: 300px;
+  padding: 12px 15px;
+  border: 2px solid #e0e0e0;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 0.3s ease;
+  box-sizing: border-box;
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
+}
+
+.form-control::placeholder {
+  color: #999;
+}
+
+.reqContent {
+  display: flex;
+  flex-direction: column; /* 세로로 쌓기 */
+  align-items: center; /* 가로 중앙 정렬 */
+  gap: 20px; /* 간격도 적당히 */
+}
+
+.btn-confirm {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 30px;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.btn-confirm {
+  background-color: #9f2120;
+  color: white;
+}
+
+.btn-confirm:hover {
+  background-color: #7d1a19;
+  box-shadow: 0 4px 12px rgba(159, 33, 32, 0.3);
+}
+
+/* 반응형 디자인 */
+@media (max-width: 768px) {
+  .main-content {
+    padding: 15px;
+  }
+
+  .button-group {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .btn-confirm {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .content-area textarea {
+    min-height: 300px;
+  }
+}

--- a/FeatherWorld/src/main/resources/static/css/guestBook/guestBook.css
+++ b/FeatherWorld/src/main/resources/static/css/guestBook/guestBook.css
@@ -93,13 +93,20 @@
 /* 방명록 수정 시 입력창 스타일 */
 .update-textarea {
   width: 630px;
-  height: 90px;
+  height: 80px;
   font-size: 16px;
   padding: 5px;
   border-radius: 6px;
   border: 1px solid #ccc;
   resize: none;
   margin-right: 15px;
+  margin-bottom: 10px;
+}
+
+.update-textarea:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
 }
 
 /* 댓글 입력창 */
@@ -136,6 +143,12 @@
   border-radius: 6px;
   border: 1px solid #ccc;
   resize: none;
+}
+
+.guestBook-textbox:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
 }
 
 /* 방명록 작성 버튼*/

--- a/FeatherWorld/src/main/resources/static/css/playList/playList.css
+++ b/FeatherWorld/src/main/resources/static/css/playList/playList.css
@@ -151,6 +151,12 @@
   display: block;
 }
 
+#youtubeUrl:focus {
+  outline: none;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
+}
+
 .embed-container {
   position: relative;
   padding-bottom: 56.25%;

--- a/FeatherWorld/src/main/resources/static/css/profile/profileupdate.css
+++ b/FeatherWorld/src/main/resources/static/css/profile/profileupdate.css
@@ -61,7 +61,6 @@
 .bio-textarea {
   width: 100%;
   height: 100px;
-  border: 2px solid #9f2120;
   background-color: #fafafa;
   border-radius: 8px;
   padding: 12px 20px;
@@ -77,9 +76,9 @@
 }
 
 .bio-textarea:focus {
-  border-color: #9f2120;
   outline: none;
-  background-color: #fff;
+  border-color: #9f2120;
+  box-shadow: 0 0 0 3px rgba(159, 33, 32, 0.1);
 }
 
 /* 버튼 영역 */

--- a/FeatherWorld/src/main/resources/static/js/friendList/incomingFriendListPart.js
+++ b/FeatherWorld/src/main/resources/static/js/friendList/incomingFriendListPart.js
@@ -192,13 +192,30 @@ function resetEditCancelBtn() {
     profileImg.style.cursor = "pointer";
     if (profileImg) {
       profileImg.addEventListener("click", () => {
-        window.location.href = `/${friend.dataset.memberNo}/friendList`;
+        window.location.href = `/${friend.dataset.memberNo}/minihome`;
       });
     }
-    profileImg.style.cursor = "pointer";
+    profileName.style.cursor = "pointer";
     if (profileName) {
       profileName.addEventListener("click", () => {
-        window.location.href = `/${friend.dataset.memberNo}/friendList`;
+        window.location.href = `/${friend.dataset.memberNo}/minihome`;
+      });
+    }
+  });
+
+  friendSendedSpans.forEach(function (friend) {
+    const profileImg2 = friend.querySelector("#toFriendImg");
+    const profileName2 = friend.querySelector("#toFriendName");
+    profileImg2.style.cursor = "pointer";
+    if (profileImg2) {
+      profileImg2.addEventListener("click", () => {
+        window.location.href = `/${friend.dataset.memberNo}/minihome`;
+      });
+    }
+    profileName2.style.cursor = "pointer";
+    if (profileName2) {
+      profileName2.addEventListener("click", () => {
+        window.location.href = `/${friend.dataset.memberNo}/minihome`;
       });
     }
   });

--- a/FeatherWorld/src/main/resources/templates/friendList/incomingFriendListPart.html
+++ b/FeatherWorld/src/main/resources/templates/friendList/incomingFriendListPart.html
@@ -192,16 +192,21 @@
         <!-- session이랑 비교하도록 되어있음. -->
         <div class="left-align">
           <img
+            id="toFriendImg"
             th:if="${ilchon.memberImg}"
             th:src="@{${ilchon.memberImg}}"
             width="20"
           />
           <img
+            id="toFriendImg"
             th:unless="${ilchon.memberImg}"
             th:src="@{/images/default/user.png}"
             width="20"
           />
-          <span class="font-bold color-gray" th:text="${ilchon.memberName}"
+          <span
+            id="toFriendName"
+            class="font-bold color-gray"
+            th:text="${ilchon.memberName}"
             >별명</span
           >
         </div>

--- a/FeatherWorld/src/main/resources/templates/friendList/sendFriendReq.html
+++ b/FeatherWorld/src/main/resources/templates/friendList/sendFriendReq.html
@@ -7,78 +7,66 @@
     <title th:text="#{app.name}">Feathers McGrew Semi Project</title>
 
     <th:block th:replace="~{common/common}"></th:block>
-    <link rel="stylesheet" href="/css/board/boardList.css" />
-    <link rel="stylesheet" href="/css/board/boardWrite.css" />
-    <style>
-      * {
-        margin: 10px;
-      }
-
-      div,
-      p,
-      section {
-        margin-left: auto;
-        margin-right: auto;
-        width: fit-content;
-      }
-
-      button {
-        justify-items: center;
-        align-items: center;
-      }
-    </style>
+    <link rel="stylesheet" href="/css/friendList/sendFriendReq.css" />
+    <!-- <link rel="stylesheet" href="/css/board/boardWrite.css" /> -->
   </head>
   <body th:attr="member-no=${memberNo}">
-    <div class="container">
-      <!-- 헤더 Include -->
-      <th:block th:replace="~{common/header}"></th:block>
+    <div class="center-page">
+      <div class="center-content">
+        <div class="container">
+          <!-- 헤더 Include -->
+          <th:block th:replace="~{common/header}"></th:block>
 
-      <div class="content-container">
-        <!-- 좌측 게시판 리스트 Include -->
-
-        <!-- 중앙 게시글 상세 -->
-        <div class="main-content">
-          <div class="board-write">
-            <button onclick="history.back()" class="back-button">
-              <span class="fa-solid fa-left-long"></span>
-            </button>
-
-            <div class="board-form">
-              <form action="/insert/newFriend" method="post">
-                <input
-                  type="text"
-                  class="form-control"
-                  placeholder="새로 정할 일촌명을 입력하세요"
-                  name="nickname"
-                />
-                <div class="byte-counter">(12/2000)bytes</div>
-                <input type="hidden" name="memberNo" th:value="${memberNo}" />
-                <button type="submit" class="btn-confirm">
-                  <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="3"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <polyline points="20 6 9 17 4 12"></polyline>
-                  </svg>
-                  SEND
-                </button>
-              </form>
+          <div class="content-container">
+            <!-- 좌측  프로필 들어올 공간 Include -->
+            <div class="left-sidebar">
+              <div th:replace="~{common/leftsidebar}"></div>
             </div>
+
+            <!-- 중앙 게시글 상세 -->
+            <div class="main-content">
+              <div class="board-write">
+                <button onclick="history.back()" class="back-button">
+                  <span class="fa-solid fa-left-long"></span>
+                </button>
+
+                <div class="board-form">
+                  <div class="reqTitle">
+                    <ul
+                      class="reqTitle-font"
+                      th:text="${session.loginMember?.memberNo == memberNo?'내 ': member.memberName + ' 님에게 '} + '일촌 요청 보내기'"
+                    ></ul>
+                  </div>
+                  <form
+                    class="reqContent"
+                    action="/insert/newFriend"
+                    method="post"
+                  >
+                    <input
+                      type="text"
+                      class="form-control"
+                      placeholder="새로 정할 일촌명을 입력하세요"
+                      name="nickname"
+                    />
+                    <input
+                      type="hidden"
+                      name="memberNo"
+                      th:value="${memberNo}"
+                    />
+                    <button type="submit" class="btn-confirm">SEND</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+
+            <!-- 우측 네비게이션 바 Include -->
+            <th:block th:replace="~{common/navSidebar}"></th:block>
           </div>
+
+          <!-- 푸터 Include -->
+          <th:block th:replace="~{common/footer}"></th:block>
         </div>
-
-        <!-- 우측 네비게이션 바 Include -->
-        <th:block th:replace="~{common/navSidebar}"></th:block>
       </div>
-
-      <!-- 푸터 Include -->
-      <th:block th:replace="~{common/footer}"></th:block>
     </div>
 
     <!-- JS 에서 쓰기 버튼 클릭 이벤트에 활용할 현재 게시판 종류 번호 선언 -->


### PR DESCRIPTION
1. 비밀의 방 css 해결
- leftsidebar, centerpage 통일, 그냥 간결하게,,,
- 구리긴 함 ㅜ

2. 내가 보낸 일촌 신청 목록에 프사, 이름 누르면 해당 멤버 미니홈피 가게.
- 준성이가 cancel 구현하면 끝날 듯

3. 각종 버튼들 opacity 90% 줬음

4. 웬만한 input창들 boardWrite에 title처럼 focus 시 9f2120 border 생기게 함 ㅋㅋ;